### PR TITLE
fix: missing-circuit-breaker and missing-timeout accumulated wrong entries

### DIFF
--- a/extjvm/discovery.go
+++ b/extjvm/discovery.go
@@ -456,10 +456,10 @@ func addHttpClientRequests(target *discovery_kit_api.Target, requests []HttpRequ
 	for _, request := range requests {
 		target.Attributes["spring-instance.http-outgoing-calls"] = append(target.Attributes["spring-instance.http-outgoing-calls"], request.Address)
 		if !request.CircuitBreaker {
-			target.Attributes["spring-instance.http-outgoing-calls.missing-circuit-breaker"] = append(target.Attributes["spring-instance.http-outgoing-calls"], request.Address)
+			target.Attributes["spring-instance.http-outgoing-calls.missing-circuit-breaker"] = append(target.Attributes["spring-instance.http-outgoing-calls.missing-circuit-breaker"], request.Address)
 		}
 		if request.Timeout == 0 {
-			target.Attributes["spring-instance.http-outgoing-calls.missing-timeout"] = append(target.Attributes["spring-instance.http-outgoing-calls"], request.Address)
+			target.Attributes["spring-instance.http-outgoing-calls.missing-timeout"] = append(target.Attributes["spring-instance.http-outgoing-calls.missing-timeout"], request.Address)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- `spring-instance.http-outgoing-calls.missing-circuit-breaker` and `.missing-timeout` were built by appending to `target.Attributes["spring-instance.http-outgoing-calls"]` (the full list) instead of their own key.
- Each loop iteration copied all previously accumulated addresses into the filtered list and then appended the current address on top — producing O(N²) entries that included every prior address regardless of the filter condition.
- For a JVM with N outgoing HTTP calls where the K-th call is missing a circuit breaker, the attribute would contain K entries instead of 1, with the first K-1 being incorrect.

## Fix

Change the `append` source on both lines from `"spring-instance.http-outgoing-calls"` to the attribute's own key, so each filtered list only grows when the condition matches.