### PR TITLE
fix: propagate underlying error when stopping an action fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix: propagate the underlying error when stopping an action fails, instead of returning a bare "Failed to stop action"
 - feat: lower `oom_score_adj` on startup via extension-kit's `extruntime.AdjustOOMScoreAdj()` to avoid being killed by the node OOM killer. The extension sets it directly using the `cap_sys_resource` file capability (default `-998`, configurable via `STEADYBIT_EXTENSION_OOM_SCORE_ADJ`).
 
 ## v1.2.17

--- a/extjvm/action_commons.go
+++ b/extjvm/action_commons.go
@@ -143,7 +143,7 @@ func (j *javaagentAction) Stop(_ context.Context, state *JavaagentActionState) (
 	var msg action_kit_api.Message
 	if javaVm != nil {
 		if err := j.stopAttack(javaVm, j.pluginJar); err != nil {
-			return nil, extension_kit.ToError("Failed to stop action", nil)
+			return nil, extension_kit.ToError("Failed to stop action", err)
 		}
 		msg.Level = extutil.Ptr(action_kit_api.Info)
 		msg.Message = fmt.Sprintf("Action on PID %d stopped", state.Pid)


### PR DESCRIPTION
The `Stop` handler in `extjvm/action_commons.go` passed `nil` instead of the actual error to `extension_kit.ToError`, so the agent only ever saw `{"title":"Failed to stop action"}` with no cause.

This made real failures (e.g. `connection not found` when the javaagent was never attached, as seen on OpenShift 4.20 with SELinux MCS label mismatches) impossible to diagnose from the agent log alone.

The `Start` path already passes the error correctly; this aligns `Stop` with it.