### PR TITLE
fix(chart): make javaagent jars readable across SELinux MCS boundaries on OpenShift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix(chart): on OpenShift, run the extension pod with an MCS-category-less SELinux level (`s0`) so target JVMs can read the mounted javaagent jars. Without this, SELinux denies the agent jar read (each namespace gets distinct MCS categories) and attacks fail with "connection not found". The SCC now uses `seLinuxContext: RunAsAny`; override via `podSecurityContext.seLinuxOptions`.
 - feat: lower `oom_score_adj` on startup via extension-kit's `extruntime.AdjustOOMScoreAdj()` to avoid being killed by the node OOM killer. The extension sets it directly using the `cap_sys_resource` file capability (default `-998`, configurable via `STEADYBIT_EXTENSION_OOM_SCORE_ADJ`).
 
 ## v1.2.17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- fix(chart): on OpenShift, run the extension pod with an MCS-category-less SELinux level (`s0`) so target JVMs can read the mounted javaagent jars. Without this, SELinux denies the agent jar read (each namespace gets distinct MCS categories) and attacks fail with "connection not found". The SCC now uses `seLinuxContext: RunAsAny`; override via `podSecurityContext.seLinuxOptions`.
+- fix(chart): on OpenShift, run the extension pod with an MCS-category-less SELinux level (`s0`) so target JVMs can read the mounted javaagent jars. Without this, SELinux denies the agent jar read (each namespace gets distinct MCS categories) and attacks fail with "connection not found". The SCC pins the level via `seLinuxContext: MustRunAs`; override via `podSecurityContext.seLinuxOptions` (mirrored into the SCC).
 - feat: lower `oom_score_adj` on startup via extension-kit's `extruntime.AdjustOOMScoreAdj()` to avoid being killed by the node OOM killer. The extension sets it directly using the `cap_sys_resource` file capability (default `-998`, configurable via `STEADYBIT_EXTENSION_OOM_SCORE_ADJ`).
 
 ## v1.2.17

--- a/charts/steadybit-extension-jvm/Chart.yaml
+++ b/charts/steadybit-extension-jvm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: steadybit-extension-jvm
 description: Steadybit jvm extension Helm chart for Kubernetes.
-version: 1.2.22
+version: 1.2.23
 appVersion: v1.2.17
 home: https://www.steadybit.com/
 icon: https://steadybit-website-assets.s3.amazonaws.com/logo-symbol-transparent.png

--- a/charts/steadybit-extension-jvm/templates/_helpers.tpl
+++ b/charts/steadybit-extension-jvm/templates/_helpers.tpl
@@ -37,6 +37,15 @@ ociRuntime.get will select the attribute for the selected container engine
 {{- end -}}
 
 {{- /*
+jvm.openshift returns "true" when running on OpenShift (or when securityContextConstraint.create is forced)
+*/}}
+{{- define "jvm.openshift" -}}
+{{- if or .Values.securityContextConstraint.create (and (.Capabilities.APIVersions.Has "security.openshift.io/v1/SecurityContextConstraints") (eq .Values.securityContextConstraint.create nil)) -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{- /*
 will omit attribute from the passed in object depending on the KubeVersion
 */}}
 {{- define "omitForKuberVersion" -}}

--- a/charts/steadybit-extension-jvm/templates/daemonset.yaml
+++ b/charts/steadybit-extension-jvm/templates/daemonset.yaml
@@ -44,7 +44,14 @@ spec:
       {{- with (.Values.priorityClassName | default (dig "priorityClassName" nil (.Values.global | default dict))) }}
       priorityClassName: {{ . }}
       {{- end }}
-      {{- with .Values.podSecurityContext }}
+      {{- $podSecurityContext := deepCopy .Values.podSecurityContext }}
+      {{- if and (include "jvm.openshift" .) (not (hasKey $podSecurityContext "seLinuxOptions")) }}
+      {{- /* On OpenShift the javaagent jars are mounted into target containers. Run the pod
+             with an MCS-category-less SELinux level so that target JVMs (confined with their
+             own per-namespace categories) are allowed to read them. */}}
+      {{- $_ := set $podSecurityContext "seLinuxOptions" (dict "level" "s0") }}
+      {{- end }}
+      {{- with $podSecurityContext }}
       securityContext:
       {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/steadybit-extension-jvm/templates/daemonset.yaml
+++ b/charts/steadybit-extension-jvm/templates/daemonset.yaml
@@ -44,7 +44,7 @@ spec:
       {{- with (.Values.priorityClassName | default (dig "priorityClassName" nil (.Values.global | default dict))) }}
       priorityClassName: {{ . }}
       {{- end }}
-      {{- $podSecurityContext := deepCopy .Values.podSecurityContext }}
+      {{- $podSecurityContext := deepCopy (.Values.podSecurityContext | default dict) }}
       {{- if and (include "jvm.openshift" .) (not (hasKey $podSecurityContext "seLinuxOptions")) }}
       {{- /* On OpenShift the javaagent jars are mounted into target containers. Run the pod
              with an MCS-category-less SELinux level so that target JVMs (confined with their

--- a/charts/steadybit-extension-jvm/templates/scc.yaml
+++ b/charts/steadybit-extension-jvm/templates/scc.yaml
@@ -16,7 +16,10 @@ runAsUser:
 seccompProfiles:
   - unconfined
 seLinuxContext:
-  # RunAsAny allows the pod to request an MCS-category-less SELinux level (s0), so that the
-  # javaagent jars mounted into target containers are readable by the confined target JVMs.
-  type: RunAsAny
+  # Pin the SELinux level to s0 (no MCS categories) so that the javaagent jars mounted into
+  # target containers are readable by the confined target JVMs. Mirrors
+  # podSecurityContext.seLinuxOptions when overridden.
+  type: MustRunAs
+  seLinuxOptions:
+    {{- .Values.podSecurityContext.seLinuxOptions | default (dict "level" "s0") | toYaml | nindent 4 }}
 {{- end -}}

--- a/charts/steadybit-extension-jvm/templates/scc.yaml
+++ b/charts/steadybit-extension-jvm/templates/scc.yaml
@@ -21,5 +21,5 @@ seLinuxContext:
   # podSecurityContext.seLinuxOptions when overridden.
   type: MustRunAs
   seLinuxOptions:
-    {{- .Values.podSecurityContext.seLinuxOptions | default (dict "level" "s0") | toYaml | nindent 4 }}
+    {{- (.Values.podSecurityContext | default dict).seLinuxOptions | default (dict "level" "s0") | toYaml | nindent 4 }}
 {{- end -}}

--- a/charts/steadybit-extension-jvm/templates/scc.yaml
+++ b/charts/steadybit-extension-jvm/templates/scc.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.securityContextConstraint.create (and (.Capabilities.APIVersions.Has "security.openshift.io/v1/SecurityContextConstraints") (eq .Values.securityContextConstraint.create nil)) -}}
+{{- if include "jvm.openshift" . -}}
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
@@ -16,5 +16,7 @@ runAsUser:
 seccompProfiles:
   - unconfined
 seLinuxContext:
-  type: MustRunAs
+  # RunAsAny allows the pod to request an MCS-category-less SELinux level (s0), so that the
+  # javaagent jars mounted into target containers are readable by the confined target JVMs.
+  type: RunAsAny
 {{- end -}}

--- a/charts/steadybit-extension-jvm/tests/__snapshot__/daemonset_test.yaml.snap
+++ b/charts/steadybit-extension-jvm/tests/__snapshot__/daemonset_test.yaml.snap
@@ -1,3 +1,313 @@
+manifest should match snapshot on openshift with custom seLinuxOptions:
+  1: |
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      labels:
+        steadybit.com/discovery-disabled: "true"
+        steadybit.com/extension: "true"
+      name: RELEASE-NAME-steadybit-extension-jvm
+      namespace: NAMESPACE
+    spec:
+      selector:
+        matchLabels:
+          app: steadybit-extension-jvm
+          app.kubernetes.io/name: steadybit-extension-jvm
+      template:
+        metadata:
+          annotations:
+            container.apparmor.security.beta.kubernetes.io/extension: unconfined
+            oneagent.dynatrace.com/injection: "false"
+            steadybit.com/extension-auto-discovery: |
+              {"extensions":[{"port":8087,"protocol":"http","types":["ACTION","DISCOVERY","ADVICE"]}]}
+            steadybit.com/extension-auto-registration: |
+              {"extensions":[{"port":8087,"protocol":"http"}]}
+          labels:
+            app: steadybit-extension-jvm
+            app.kubernetes.io/name: steadybit-extension-jvm
+            steadybit.com/discovery-disabled: "true"
+            steadybit.com/extension: "true"
+        spec:
+          containers:
+            - env:
+                - name: STEADYBIT_EXTENSION_PORT
+                  value: "8087"
+                - name: STEADYBIT_EXTENSION_HEALTH_PORT
+                  value: "8083"
+                - name: STEADYBIT_EXTENSION_JAVA_AGENT_LOG_LEVEL
+                  value: INFO
+                - name: STEADYBIT_EXTENSION_JVM_ATTACHMENT_ENABLED
+                  value: "true"
+                - name: STEADYBIT_EXTENSION_JVM_ATTACHMENT_PORT
+                  value: "0"
+                - name: STEADYBIT_EXTENSION_OCIRUNTIME_DEBUG
+                  value: "false"
+                - name: STEADYBIT_EXTENSION_OCIRUNTIME_ROOT
+                  value: /run/containerd/runc/k8s.io
+                - name: STEADYBIT_EXTENSION_OCIRUNTIME_PATH
+                  value: runc
+                - name: STEADYBIT_LOG_LEVEL
+                  value: INFO
+                - name: STEADYBIT_LOG_FORMAT
+                  value: text
+              image: ghcr.io/steadybit/extension-jvm:v0.0.0
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                failureThreshold: 5
+                httpGet:
+                  path: /health/liveness
+                  port: 8083
+                initialDelaySeconds: 10
+                periodSeconds: 10
+                successThreshold: 1
+                timeoutSeconds: 5
+              name: extension
+              ports:
+                - containerPort: 8087
+                  name: http
+                - containerPort: 8083
+                  name: health
+              readinessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /health/readiness
+                  port: 8083
+                initialDelaySeconds: 10
+                periodSeconds: 10
+                successThreshold: 1
+                timeoutSeconds: 1
+              resources:
+                limits:
+                  cpu: 500m
+                  memory: 96Mi
+                requests:
+                  cpu: 100m
+                  memory: 48Mi
+              securityContext:
+                capabilities:
+                  add:
+                    - SYS_ADMIN
+                    - SYS_CHROOT
+                    - SYS_RESOURCE
+                    - SYS_PTRACE
+                    - KILL
+                    - NET_ADMIN
+                    - DAC_OVERRIDE
+                    - SETUID
+                    - SETGID
+                    - AUDIT_WRITE
+                readOnlyRootFilesystem: true
+                seccompProfile:
+                  type: Unconfined
+              volumeMounts:
+                - mountPath: /javaagent
+                  name: javaagent-libs
+                - mountPath: /tmp
+                  name: tmp-dir
+                - mountPath: /sys/fs/cgroup
+                  name: cgroup-root
+                - mountPath: /run/containerd/containerd.sock
+                  name: containerengine-socket
+                - mountPath: /run/containerd/runc/k8s.io
+                  name: ociruntime-root
+          dnsPolicy: ClusterFirstWithHostNet
+          hostNetwork: true
+          hostPID: true
+          initContainers:
+            - command:
+                - sh
+                - -c
+                - cp -R /javaagent/* /javaagent-rw/
+              image: ghcr.io/steadybit/extension-jvm:v0.0.0
+              imagePullPolicy: IfNotPresent
+              name: init-javaagent-libs
+              volumeMounts:
+                - mountPath: /javaagent-rw
+                  name: javaagent-libs
+          securityContext:
+            runAsNonRoot: true
+            seLinuxOptions:
+              level: s0:c123,c456
+            seccompProfile:
+              type: Unconfined
+          serviceAccountName: steadybit-extension-jvm
+          volumes:
+            - emptyDir: {}
+              name: tmp-dir
+            - emptyDir:
+                medium: Memory
+              name: javaagent-libs
+            - hostPath:
+                path: /sys/fs/cgroup
+                type: Directory
+              name: cgroup-root
+            - hostPath:
+                path: /run/containerd/runc/k8s.io
+                type: Directory
+              name: ociruntime-root
+            - hostPath:
+                path: /run/containerd/containerd.sock
+                type: Socket
+              name: containerengine-socket
+      updateStrategy:
+        rollingUpdate:
+          maxUnavailable: 1
+        type: RollingUpdate
+manifest should match snapshot on openshift with default seLinuxOptions:
+  1: |
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      labels:
+        steadybit.com/discovery-disabled: "true"
+        steadybit.com/extension: "true"
+      name: RELEASE-NAME-steadybit-extension-jvm
+      namespace: NAMESPACE
+    spec:
+      selector:
+        matchLabels:
+          app: steadybit-extension-jvm
+          app.kubernetes.io/name: steadybit-extension-jvm
+      template:
+        metadata:
+          annotations:
+            container.apparmor.security.beta.kubernetes.io/extension: unconfined
+            oneagent.dynatrace.com/injection: "false"
+            steadybit.com/extension-auto-discovery: |
+              {"extensions":[{"port":8087,"protocol":"http","types":["ACTION","DISCOVERY","ADVICE"]}]}
+            steadybit.com/extension-auto-registration: |
+              {"extensions":[{"port":8087,"protocol":"http"}]}
+          labels:
+            app: steadybit-extension-jvm
+            app.kubernetes.io/name: steadybit-extension-jvm
+            steadybit.com/discovery-disabled: "true"
+            steadybit.com/extension: "true"
+        spec:
+          containers:
+            - env:
+                - name: STEADYBIT_EXTENSION_PORT
+                  value: "8087"
+                - name: STEADYBIT_EXTENSION_HEALTH_PORT
+                  value: "8083"
+                - name: STEADYBIT_EXTENSION_JAVA_AGENT_LOG_LEVEL
+                  value: INFO
+                - name: STEADYBIT_EXTENSION_JVM_ATTACHMENT_ENABLED
+                  value: "true"
+                - name: STEADYBIT_EXTENSION_JVM_ATTACHMENT_PORT
+                  value: "0"
+                - name: STEADYBIT_EXTENSION_OCIRUNTIME_DEBUG
+                  value: "false"
+                - name: STEADYBIT_EXTENSION_OCIRUNTIME_ROOT
+                  value: /run/containerd/runc/k8s.io
+                - name: STEADYBIT_EXTENSION_OCIRUNTIME_PATH
+                  value: runc
+                - name: STEADYBIT_LOG_LEVEL
+                  value: INFO
+                - name: STEADYBIT_LOG_FORMAT
+                  value: text
+              image: ghcr.io/steadybit/extension-jvm:v0.0.0
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                failureThreshold: 5
+                httpGet:
+                  path: /health/liveness
+                  port: 8083
+                initialDelaySeconds: 10
+                periodSeconds: 10
+                successThreshold: 1
+                timeoutSeconds: 5
+              name: extension
+              ports:
+                - containerPort: 8087
+                  name: http
+                - containerPort: 8083
+                  name: health
+              readinessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /health/readiness
+                  port: 8083
+                initialDelaySeconds: 10
+                periodSeconds: 10
+                successThreshold: 1
+                timeoutSeconds: 1
+              resources:
+                limits:
+                  cpu: 500m
+                  memory: 96Mi
+                requests:
+                  cpu: 100m
+                  memory: 48Mi
+              securityContext:
+                capabilities:
+                  add:
+                    - SYS_ADMIN
+                    - SYS_CHROOT
+                    - SYS_RESOURCE
+                    - SYS_PTRACE
+                    - KILL
+                    - NET_ADMIN
+                    - DAC_OVERRIDE
+                    - SETUID
+                    - SETGID
+                    - AUDIT_WRITE
+                readOnlyRootFilesystem: true
+                seccompProfile:
+                  type: Unconfined
+              volumeMounts:
+                - mountPath: /javaagent
+                  name: javaagent-libs
+                - mountPath: /tmp
+                  name: tmp-dir
+                - mountPath: /sys/fs/cgroup
+                  name: cgroup-root
+                - mountPath: /run/containerd/containerd.sock
+                  name: containerengine-socket
+                - mountPath: /run/containerd/runc/k8s.io
+                  name: ociruntime-root
+          dnsPolicy: ClusterFirstWithHostNet
+          hostNetwork: true
+          hostPID: true
+          initContainers:
+            - command:
+                - sh
+                - -c
+                - cp -R /javaagent/* /javaagent-rw/
+              image: ghcr.io/steadybit/extension-jvm:v0.0.0
+              imagePullPolicy: IfNotPresent
+              name: init-javaagent-libs
+              volumeMounts:
+                - mountPath: /javaagent-rw
+                  name: javaagent-libs
+          securityContext:
+            runAsNonRoot: true
+            seLinuxOptions:
+              level: s0
+            seccompProfile:
+              type: Unconfined
+          serviceAccountName: steadybit-extension-jvm
+          volumes:
+            - emptyDir: {}
+              name: tmp-dir
+            - emptyDir:
+                medium: Memory
+              name: javaagent-libs
+            - hostPath:
+                path: /sys/fs/cgroup
+                type: Directory
+              name: cgroup-root
+            - hostPath:
+                path: /run/containerd/runc/k8s.io
+                type: Directory
+              name: ociruntime-root
+            - hostPath:
+                path: /run/containerd/containerd.sock
+                type: Socket
+              name: containerengine-socket
+      updateStrategy:
+        rollingUpdate:
+          maxUnavailable: 1
+        type: RollingUpdate
 manifest should match snapshot using containerd and resources:
   1: |
     apiVersion: apps/v1

--- a/charts/steadybit-extension-jvm/tests/__snapshot__/daemonset_test.yaml.snap
+++ b/charts/steadybit-extension-jvm/tests/__snapshot__/daemonset_test.yaml.snap
@@ -308,6 +308,158 @@ manifest should match snapshot on openshift with default seLinuxOptions:
         rollingUpdate:
           maxUnavailable: 1
         type: RollingUpdate
+manifest should match snapshot on openshift with null podSecurityContext:
+  1: |
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      labels:
+        steadybit.com/discovery-disabled: "true"
+        steadybit.com/extension: "true"
+      name: RELEASE-NAME-steadybit-extension-jvm
+      namespace: NAMESPACE
+    spec:
+      selector:
+        matchLabels:
+          app: steadybit-extension-jvm
+          app.kubernetes.io/name: steadybit-extension-jvm
+      template:
+        metadata:
+          annotations:
+            container.apparmor.security.beta.kubernetes.io/extension: unconfined
+            oneagent.dynatrace.com/injection: "false"
+            steadybit.com/extension-auto-discovery: |
+              {"extensions":[{"port":8087,"protocol":"http","types":["ACTION","DISCOVERY","ADVICE"]}]}
+            steadybit.com/extension-auto-registration: |
+              {"extensions":[{"port":8087,"protocol":"http"}]}
+          labels:
+            app: steadybit-extension-jvm
+            app.kubernetes.io/name: steadybit-extension-jvm
+            steadybit.com/discovery-disabled: "true"
+            steadybit.com/extension: "true"
+        spec:
+          containers:
+            - env:
+                - name: STEADYBIT_EXTENSION_PORT
+                  value: "8087"
+                - name: STEADYBIT_EXTENSION_HEALTH_PORT
+                  value: "8083"
+                - name: STEADYBIT_EXTENSION_JAVA_AGENT_LOG_LEVEL
+                  value: INFO
+                - name: STEADYBIT_EXTENSION_JVM_ATTACHMENT_ENABLED
+                  value: "true"
+                - name: STEADYBIT_EXTENSION_JVM_ATTACHMENT_PORT
+                  value: "0"
+                - name: STEADYBIT_EXTENSION_OCIRUNTIME_DEBUG
+                  value: "false"
+                - name: STEADYBIT_EXTENSION_OCIRUNTIME_ROOT
+                  value: /run/containerd/runc/k8s.io
+                - name: STEADYBIT_EXTENSION_OCIRUNTIME_PATH
+                  value: runc
+                - name: STEADYBIT_LOG_LEVEL
+                  value: INFO
+                - name: STEADYBIT_LOG_FORMAT
+                  value: text
+              image: ghcr.io/steadybit/extension-jvm:v0.0.0
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                failureThreshold: 5
+                httpGet:
+                  path: /health/liveness
+                  port: 8083
+                initialDelaySeconds: 10
+                periodSeconds: 10
+                successThreshold: 1
+                timeoutSeconds: 5
+              name: extension
+              ports:
+                - containerPort: 8087
+                  name: http
+                - containerPort: 8083
+                  name: health
+              readinessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /health/readiness
+                  port: 8083
+                initialDelaySeconds: 10
+                periodSeconds: 10
+                successThreshold: 1
+                timeoutSeconds: 1
+              resources:
+                limits:
+                  cpu: 500m
+                  memory: 96Mi
+                requests:
+                  cpu: 100m
+                  memory: 48Mi
+              securityContext:
+                capabilities:
+                  add:
+                    - SYS_ADMIN
+                    - SYS_CHROOT
+                    - SYS_RESOURCE
+                    - SYS_PTRACE
+                    - KILL
+                    - NET_ADMIN
+                    - DAC_OVERRIDE
+                    - SETUID
+                    - SETGID
+                    - AUDIT_WRITE
+                readOnlyRootFilesystem: true
+                seccompProfile:
+                  type: Unconfined
+              volumeMounts:
+                - mountPath: /javaagent
+                  name: javaagent-libs
+                - mountPath: /tmp
+                  name: tmp-dir
+                - mountPath: /sys/fs/cgroup
+                  name: cgroup-root
+                - mountPath: /run/containerd/containerd.sock
+                  name: containerengine-socket
+                - mountPath: /run/containerd/runc/k8s.io
+                  name: ociruntime-root
+          dnsPolicy: ClusterFirstWithHostNet
+          hostNetwork: true
+          hostPID: true
+          initContainers:
+            - command:
+                - sh
+                - -c
+                - cp -R /javaagent/* /javaagent-rw/
+              image: ghcr.io/steadybit/extension-jvm:v0.0.0
+              imagePullPolicy: IfNotPresent
+              name: init-javaagent-libs
+              volumeMounts:
+                - mountPath: /javaagent-rw
+                  name: javaagent-libs
+          securityContext:
+            seLinuxOptions:
+              level: s0
+          serviceAccountName: steadybit-extension-jvm
+          volumes:
+            - emptyDir: {}
+              name: tmp-dir
+            - emptyDir:
+                medium: Memory
+              name: javaagent-libs
+            - hostPath:
+                path: /sys/fs/cgroup
+                type: Directory
+              name: cgroup-root
+            - hostPath:
+                path: /run/containerd/runc/k8s.io
+                type: Directory
+              name: ociruntime-root
+            - hostPath:
+                path: /run/containerd/containerd.sock
+                type: Socket
+              name: containerengine-socket
+      updateStrategy:
+        rollingUpdate:
+          maxUnavailable: 1
+        type: RollingUpdate
 manifest should match snapshot using containerd and resources:
   1: |
     apiVersion: apps/v1

--- a/charts/steadybit-extension-jvm/tests/daemonset_test.yaml
+++ b/charts/steadybit-extension-jvm/tests/daemonset_test.yaml
@@ -124,6 +124,24 @@ tests:
     asserts:
       - matchSnapshot: {}
 
+  - it: manifest should match snapshot on openshift with default seLinuxOptions
+    capabilities:
+      apiVersions:
+        - security.openshift.io/v1/SecurityContextConstraints
+    asserts:
+      - matchSnapshot: {}
+
+  - it: manifest should match snapshot on openshift with custom seLinuxOptions
+    capabilities:
+      apiVersions:
+        - security.openshift.io/v1/SecurityContextConstraints
+    set:
+      podSecurityContext:
+        seLinuxOptions:
+          level: "s0:c123,c456"
+    asserts:
+      - matchSnapshot: {}
+
   - it: manifest should match snapshot with priority class
     set:
       priorityClassName: my-priority-class

--- a/charts/steadybit-extension-jvm/tests/daemonset_test.yaml
+++ b/charts/steadybit-extension-jvm/tests/daemonset_test.yaml
@@ -131,6 +131,15 @@ tests:
     asserts:
       - matchSnapshot: {}
 
+  - it: manifest should match snapshot on openshift with null podSecurityContext
+    capabilities:
+      apiVersions:
+        - security.openshift.io/v1/SecurityContextConstraints
+    set:
+      podSecurityContext: null
+    asserts:
+      - matchSnapshot: {}
+
   - it: manifest should match snapshot on openshift with custom seLinuxOptions
     capabilities:
       apiVersions:

--- a/charts/steadybit-extension-jvm/values.yaml
+++ b/charts/steadybit-extension-jvm/values.yaml
@@ -127,6 +127,9 @@ affinity: {}
 priorityClassName: null
 
 # podSecurityContext -- SecurityContext to apply to the pod.
+#  On OpenShift, seLinuxOptions defaults to `level: s0` (no MCS categories) so that the javaagent
+#  jars mounted into target containers are readable by the confined target JVMs. Set your own
+#  seLinuxOptions here to override that default.
 podSecurityContext:
   seccompProfile:
     type: Unconfined


### PR DESCRIPTION
## Problem

On OpenShift, JVM attacks fail with `Failed to start action: connection not found`.

Every OpenShift namespace gets distinct SELinux MCS categories. The javaagent jars live in the extension pod's `javaagent-libs` emptyDir, which kubelet labels with the **extension's** categories (e.g. `container_file_t:s0:c4,c29`). When nsmounted into a target container, the confined target JVM (e.g. `container_t:s0:c9,c29`) is denied reading them:

- the JVM logs `Error opening zip file or JAR manifest missing: /tmp/.steadybit/javaagent-init.jar`
- the extension logs `did not call back after 90 seconds` for every attach
- attacks fail with `connection not found` (the JVM is still discovered, so it remains selectable as a target)

The attach exec itself succeeds (it runs from the extension's context), which made this hard to spot — the failure only surfaces inside the target JVM.

## Fix

On OpenShift (detected via the SCC API group, same condition as SCC creation):
- default the pod-level `seLinuxOptions` to `level: s0` (no MCS categories) → the emptyDir and the jars are labeled `container_file_t:s0`, readable by all confined containers
- the SCC pins that label: `seLinuxContext: MustRunAs` with an explicit `seLinuxOptions: {level: s0}` — only the exact level the chart configures is admitted (tighter than `RunAsAny`, which would also allow e.g. `spc_t`)

The extension process itself stays confined as `container_t` — no `privileged`, no `spc_t`. Users can override via `podSecurityContext.seLinuxOptions`; the override is mirrored into the SCC so it still passes admission. Non-OpenShift rendering is unchanged (existing snapshots untouched).

## Validation

Tested end-to-end on OpenShift 4.20.22 (ROSA sandbox):
- with the current chart: 0 javaagent callbacks, all attaches time out, SELinux label mismatch confirmed via `ls -Z` on the node
- with `seLinuxOptions: {level: s0}` only (no privileged, default `container_t`): all 7 JVMs across 3 nodes attach and call back, discovery intact, java-method-delay attack runs successfully
- with the final `MustRunAs`-pinned SCC and no privileged grant: pods are admitted by the chart SCC, admission injects the pod-level `s0` default even without it in the pod spec, attacks run successfully

The mechanism (pod seLinuxOptions → CRI-O mount label, SCC validation) is identical on older OpenShift 4.x versions, so no version gating is needed.