### PR TITLE
chore(deps): bump go to 1.26.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '^1.26.4'
+          go-version: '^1.26.5'
 
       - name: Set up JDK 21
         uses: actions/setup-java@v5
@@ -211,7 +211,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '^1.26.4'
+          go-version: '^1.26.5'
 
       - name: Export GPG key
         env:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/steadybit/extension-jvm
 
-go 1.26.4
+go 1.26.5
 
 require (
 	codnect.io/chrono v1.1.3


### PR DESCRIPTION
Bump Go to 1.26.5 in go.mod and CI. Also ran `go fix` and `go mod tidy`.