### PR TITLE
chore: run audit job on free ubuntu-latest runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,8 +49,7 @@ jobs:
     name: Audit
     needs:
       - build_jars
-    runs-on:
-      labels: steadybit_runner_ubuntu_latest_4cores_16GB
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
       sonar_available: ${{ secrets.SONAR_TOKEN  != '' && 'true' || 'false' }}


### PR DESCRIPTION
## What
Switch the `audit` job from the billed larger runner `steadybit_runner_ubuntu_latest_4cores_16GB` to the standard **`ubuntu-latest`** runner.

## Why
This is a **public** repo, where the standard runner is 4 vCPU / 16 GB and standard-runner minutes are **free/unlimited**. The larger runner has identical specs but is billed, so this drops the cost to $0.

## Scope & safety
- Only the `audit` job is affected; `build-images` (multi-arch Docker) already runs on `ubuntu-latest`.
- The job starts minikube with `memory 8g`, which fits within the 16 GB standard runner. Auto-merge gates on the `audit` check, so this only merges if minikube + `make audit` pass on the standard runner.