### PR TITLE
test(jvm): run the minikube e2e against the in-repo sample

### DIFF
--- a/e2e/integration_test.go
+++ b/e2e/integration_test.go
@@ -121,12 +121,15 @@ func getSpringBootSampleTarget(t *testing.T, ctx context.Context, e *e2e.Extensi
 	target, err := e2e.PollForTarget(ctx, e, "com.steadybit.extension_jvm.jvm-instance", func(target discovery_kit_api.Target) bool {
 		//The application context is instrumented whenever an event is thrown. We make sure that events happen by calling a http endpoint in the application
 		springBootSample.AssertIsReachable(t, true)
+		// Call the JDBC-backed endpoint so the agent captures the datasource: getConnection
+		// is instrumented on first use after attach, and /mvc never touches the database.
+		_, _ = springBootSample.MeasureLatencyOnPath(200, "/jdbc")
 
 		fmt.Printf("targetApplication: %+v\n", target.Attributes)
 		return e2e.HasAttribute(target, "jvm-instance.name", "app") &&
 			e2e.HasAttribute(target, "instance.type", "spring-boot") &&
 			e2e.HasAttribute(target, "datasource.jdbc-url", "jdbc:h2:mem:testdb") &&
-			e2e.HasAttribute(target, "spring-instance.name", "spring-boot-sample") &&
+			e2e.HasAttribute(target, "spring-instance.name", "jvm-matrix-sample") &&
 			e2e.HasAttribute(target, "spring-instance.jdbc-template", "true")
 	})
 	require.NoError(t, err)
@@ -170,7 +173,7 @@ func testMvcDelay(t *testing.T, _ *e2e.Minikube, e *e2e.Extension) {
 			Duration: 10000,
 			Delay:    tt.delay,
 			Jitter:   tt.jitter,
-			Pattern:  "/customers",
+			Pattern:  "/mvc",
 			Method:   "GET",
 		}
 
@@ -187,7 +190,7 @@ func testMvcDelay(t *testing.T, _ *e2e.Minikube, e *e2e.Extension) {
 			if tt.expectedDelay {
 				springBootSample.AssertLatency(t, getMinLatency(unaffectedLatency, config.Delay), getMaxLatency(unaffectedLatency, config.Delay), unaffectedLatency)
 			} else {
-				springBootSample.AssertLatency(t, 1*time.Millisecond, unaffectedLatency*2*time.Millisecond, unaffectedLatency)
+				springBootSample.AssertLatency(t, 1*time.Millisecond, unaffectedLatency*2, unaffectedLatency)
 			}
 			require.NoError(t, action.Cancel())
 		})
@@ -218,7 +221,7 @@ func testMvcException(t *testing.T, _ *e2e.Minikube, e *e2e.Extension) {
 		}{
 			Duration:          10000,
 			ErroneousCallRate: tt.erroneousCallRate,
-			Pattern:           "/customers",
+			Pattern:           "/mvc",
 			Method:            "GET",
 		}
 
@@ -300,16 +303,16 @@ func testHttpClientDelay(t *testing.T, _ *e2e.Minikube, e *e2e.Extension) {
 			springBootSample.AssertIsReachable(t, true)
 
 			//measure customer endpoint
-			unaffectedLatency, err := springBootSample.MeasureUnaffectedLatencyOnPath(200, "/remote/blocking?url=https://github.com/steadybit")
+			unaffectedLatency, err := springBootSample.MeasureUnaffectedLatencyOnPath(200, "/http/resttemplate?url=https://github.com/steadybit")
 			require.NoError(t, err, "failed to measure customers endpoint")
 
 			action, err := e.RunAction(extjvm.ActionIDPrefix+".spring-httpclient-delay-attack", getTarget(t, e), config, nil)
 			defer func() { _ = action.Cancel() }()
 			require.NoError(t, err)
 			if tt.expectedDelay {
-				springBootSample.AssertLatencyOnPath(t, getMinLatency(unaffectedLatency, config.Delay), getMaxLatency(unaffectedLatency, config.Delay), "/remote/blocking?url=https://github.com/steadybit", unaffectedLatency)
+				springBootSample.AssertLatencyOnPath(t, getMinLatency(unaffectedLatency, config.Delay), getMaxLatency(unaffectedLatency, config.Delay), "/http/resttemplate?url=https://github.com/steadybit", unaffectedLatency)
 			} else {
-				springBootSample.AssertLatencyOnPath(t, 1*time.Millisecond, unaffectedLatency*2*time.Millisecond, "/remote/blocking?url=https://github.com/steadybit", 0)
+				springBootSample.AssertLatencyOnPath(t, 1*time.Millisecond, unaffectedLatency*2, "/http/resttemplate?url=https://github.com/steadybit", 0)
 			}
 			require.NoError(t, action.Cancel())
 		})
@@ -324,51 +327,48 @@ func getMaxLatency(unaffectedLatency time.Duration, delay uint64) time.Duration 
 	return unaffectedLatency + time.Duration(delay)*time.Millisecond*350/100
 }
 
-func testHttpClientStatus(t *testing.T, m *e2e.Minikube, e *e2e.Extension) {
+func testHttpClientStatus(t *testing.T, _ *e2e.Minikube, e *e2e.Extension) {
 
+	// expectedStatus is the status the WebClient endpoint surfaces: the injected code
+	// when the attack fires (host matches, within the erroneous rate), otherwise 200.
 	tests := []struct {
-		name               string
-		erroneousCallRate  int
-		hostAddress        string
-		expectedLogStatus  int
-		expectedHttpStatus int
-		failureTypes       []string
+		name              string
+		erroneousCallRate int
+		hostAddress       string
+		expectedStatus    int
+		failureTypes      []string
 	}{
 		{
-			name:               "should not throw http client exceptions",
-			erroneousCallRate:  0,
-			expectedHttpStatus: 200,
-			failureTypes:       []string{},
+			name:              "should not throw http client exceptions",
+			erroneousCallRate: 0,
+			expectedStatus:    200,
+			failureTypes:      []string{},
 		},
 		{
-			name:               "should throw http client exceptions",
-			erroneousCallRate:  100,
-			failureTypes:       []string{},
-			expectedLogStatus:  500,
-			expectedHttpStatus: 500,
+			name:              "should throw http client exceptions",
+			erroneousCallRate: 100,
+			failureTypes:      []string{},
+			expectedStatus:    500,
 		},
 		{
-			name:               "should throw http client exceptions on host and set http status",
-			erroneousCallRate:  100,
-			failureTypes:       []string{"HTTP_502"},
-			expectedLogStatus:  502,
-			expectedHttpStatus: 500,
-			hostAddress:        "www.github.com:443",
+			name:              "should throw http client exceptions on host and set http status",
+			erroneousCallRate: 100,
+			failureTypes:      []string{"HTTP_502"},
+			expectedStatus:    502,
+			hostAddress:       "www.github.com:443",
 		},
 		{
-			name:               "should not throw http client exceptions on host",
-			erroneousCallRate:  100,
-			failureTypes:       []string{},
-			expectedLogStatus:  200,
-			expectedHttpStatus: 200,
-			hostAddress:        "steadybit.github.com",
+			name:              "should not throw http client exceptions on host",
+			erroneousCallRate: 100,
+			failureTypes:      []string{},
+			expectedStatus:    200,
+			hostAddress:       "steadybit.github.com",
 		},
 		{
-			name:               "should throw http client exceptions sometimes",
-			erroneousCallRate:  50,
-			failureTypes:       []string{},
-			expectedLogStatus:  500,
-			expectedHttpStatus: 500,
+			name:              "should throw http client exceptions sometimes",
+			erroneousCallRate: 50,
+			failureTypes:      []string{},
+			expectedStatus:    500,
 		},
 	}
 
@@ -393,22 +393,20 @@ func testHttpClientStatus(t *testing.T, m *e2e.Minikube, e *e2e.Extension) {
 			FailureCauses:     tt.failureTypes,
 		}
 
-		t.Run(tt.name, func(t *testing.T) {
-			springBootSample.AssertIsReachable(t, true)
+		// Exercise both the reactive (WebClient) and blocking (RestTemplate) clients: the status attack
+		// takes effect for both on Spring Framework 6+ (the in-repo sample runs Spring Boot 3.5). Each
+		// endpoint surfaces the downstream status so we can assert the exact injected code.
+		for _, endpoint := range []string{"/http/webclient", "/http/resttemplate"} {
+			t.Run(tt.name+" ["+endpoint+"]", func(t *testing.T) {
+				springBootSample.AssertIsReachable(t, true)
 
-			action, err := e.RunAction(extjvm.ActionIDPrefix+".spring-httpclient-status-attack", getTarget(t, e), config, nil)
-			defer func() { _ = action.Cancel() }()
-			require.NoError(t, err)
-			if tt.erroneousCallRate > 0 {
-				springBootSample.AssertStatusOnPath(t, tt.expectedHttpStatus, "/remote/blocking?url=https://www.github.com")
-				if tt.expectedLogStatus != 200 {
-					e2e.AssertLogContains(t, m, springBootSample.Pod, fmt.Sprintf("%d Injected by steadybit", tt.expectedLogStatus))
-				}
-			} else {
-				springBootSample.AssertStatusOnPath(t, tt.expectedHttpStatus, "/remote/blocking?url=https://www.github.com")
-			}
-			require.NoError(t, action.Cancel())
-		})
+				action, err := e.RunAction(extjvm.ActionIDPrefix+".spring-httpclient-status-attack", getTarget(t, e), config, nil)
+				defer func() { _ = action.Cancel() }()
+				require.NoError(t, err)
+				springBootSample.AssertStatusOnPath(t, tt.expectedStatus, endpoint+"?url=https://www.github.com")
+				require.NoError(t, action.Cancel())
+			})
+		}
 	}
 }
 
@@ -450,8 +448,8 @@ func testJavaMethodDelay(t *testing.T, _ *e2e.Minikube, e *e2e.Extension) {
 			Duration:   10000,
 			Delay:      tt.delay,
 			Jitter:     tt.jitter,
-			ClassName:  "com.steadybit.samples.data.CustomerController",
-			MethodName: "getAllCustomers",
+			ClassName:  "com.steadybit.matrix.ComputeService",
+			MethodName: "compute",
 		}
 
 		t.Run(tt.name, func(t *testing.T) {
@@ -467,7 +465,7 @@ func testJavaMethodDelay(t *testing.T, _ *e2e.Minikube, e *e2e.Extension) {
 			if tt.expectedDelay {
 				springBootSample.AssertLatency(t, getMinLatency(unaffectedLatency, config.Delay), getMaxLatency(unaffectedLatency, config.Delay), unaffectedLatency)
 			} else {
-				springBootSample.AssertLatency(t, 1*time.Millisecond, unaffectedLatency*2*time.Millisecond, unaffectedLatency)
+				springBootSample.AssertLatency(t, 1*time.Millisecond, unaffectedLatency*2, unaffectedLatency)
 			}
 			require.NoError(t, action.Cancel())
 		})
@@ -499,8 +497,8 @@ func testJavaMethodException(t *testing.T, _ *e2e.Minikube, e *e2e.Extension) {
 		}{
 			Duration:          10000,
 			ErroneousCallRate: tt.erroneousCallRate,
-			ClassName:         "com.steadybit.samples.data.CustomerController",
-			MethodName:        "getAllCustomers",
+			ClassName:         "com.steadybit.matrix.ComputeService",
+			MethodName:        "compute",
 		}
 
 		t.Run(tt.name, func(t *testing.T) {
@@ -602,17 +600,17 @@ func testJDBCTemplateDelay(t *testing.T, _ *e2e.Minikube, e *e2e.Extension) {
 		t.Run(tt.name, func(t *testing.T) {
 			springBootSample.AssertIsReachable(t, true)
 
-			//measure customer endpoint
-			unaffectedLatency, err := springBootSample.MeasureLatency(200)
-			require.NoError(t, err, "failed to measure customers endpoint")
+			// measure the JDBC-backed endpoint (the delay affects JdbcTemplate operations)
+			unaffectedLatency, err := springBootSample.MeasureLatencyOnPath(200, "/jdbc")
+			require.NoError(t, err, "failed to measure jdbc endpoint")
 
 			action, err := e.RunAction(extjvm.ActionIDPrefix+".spring-jdbctemplate-delay-attack", getTarget(t, e), config, nil)
 			defer func() { _ = action.Cancel() }()
 			require.NoError(t, err)
 			if tt.expectedDelay {
-				springBootSample.AssertLatency(t, getMinLatency(unaffectedLatency, config.Delay), getMaxLatency(unaffectedLatency, config.Delay), unaffectedLatency)
+				springBootSample.AssertLatencyOnPath(t, getMinLatency(unaffectedLatency, config.Delay), getMaxLatency(unaffectedLatency, config.Delay), "/jdbc", unaffectedLatency)
 			} else {
-				springBootSample.AssertLatency(t, 1*time.Millisecond, unaffectedLatency*2*time.Millisecond, unaffectedLatency)
+				springBootSample.AssertLatencyOnPath(t, 1*time.Millisecond, unaffectedLatency*2, "/jdbc", unaffectedLatency)
 			}
 			require.NoError(t, action.Cancel())
 		})
@@ -653,25 +651,25 @@ func testJDBCTemplateException(t *testing.T, _ *e2e.Minikube, e *e2e.Extension) 
 		config := struct {
 			Duration          int    `json:"duration"`
 			ErroneousCallRate int    `json:"erroneousCallRate"`
-			ClassName         string `json:"className"`
-			MethodName        string `json:"methodName"`
+			JdbcUrl           string `json:"jdbcUrl"`
+			Operations        string `json:"operations"`
 		}{
 			Duration:          10000,
 			ErroneousCallRate: tt.erroneousCallRate,
-			ClassName:         "com.steadybit.samples.data.CustomerController",
-			MethodName:        "getAllCustomers",
+			JdbcUrl:           tt.jdbcUrl,
+			Operations:        tt.operations,
 		}
 
 		t.Run(tt.name, func(t *testing.T) {
 			springBootSample.AssertIsReachable(t, true)
 
-			action, err := e.RunAction(extjvm.ActionIDPrefix+".java-method-exception-attack", getTarget(t, e), config, nil)
+			action, err := e.RunAction(extjvm.ActionIDPrefix+".spring-jdbctemplate-exception-attack", getTarget(t, e), config, nil)
 			defer func() { _ = action.Cancel() }()
 			require.NoError(t, err)
 			if tt.erroneousCallRate > 0 {
-				springBootSample.AssertStatus(t, 500)
+				springBootSample.AssertStatusOnPath(t, 500, "/jdbc")
 			} else {
-				springBootSample.AssertStatus(t, 200)
+				springBootSample.AssertStatusOnPath(t, 200, "/jdbc")
 			}
 			require.NoError(t, action.Cancel())
 		})

--- a/e2e/matrix/attacks.go
+++ b/e2e/matrix/attacks.go
@@ -34,9 +34,12 @@ type AttackSpec struct {
 }
 
 // effectObserved reports whether a probe (status, latency) shows the attack's effect.
-func (s AttackSpec) effectObserved(code int, latencySecs float64) bool {
+// For delay attacks the latency must rise above the baseline by the threshold, so a
+// merely slow endpoint (high baseline, or a transient spike near it) isn't mistaken for
+// an injected delay.
+func (s AttackSpec) effectObserved(code int, latencySecs, baselineSecs float64) bool {
 	if s.Mode == modeDelay {
-		return latencySecs >= delayThresholdSecs
+		return latencySecs-baselineSecs >= delayThresholdSecs
 	}
 	return code >= 500
 }

--- a/e2e/matrix/harness.go
+++ b/e2e/matrix/harness.go
@@ -251,7 +251,7 @@ func (h *Harness) enriched(t *target) bool {
 }
 
 type target struct {
-	ID         string              `json:"target"`
+	ID         string              `json:"id"`
 	Attributes map[string][]string `json:"attributes"`
 }
 
@@ -283,7 +283,8 @@ func (h *Harness) RunAttack(spec AttackSpec) AttackResult {
 		res.Result, res.Detail = "error", "sample target not found"
 		return res
 	}
-	res.Baseline = obs(h.probe(spec.Endpoint))
+	baseCode, baseT := h.probe(spec.Endpoint)
+	res.Baseline = obs(baseCode, baseT)
 
 	exec := uuid.New().String()
 	path := "/" + actionPrefix + spec.ActionID
@@ -314,7 +315,7 @@ func (h *Harness) RunAttack(spec AttackSpec) AttackResult {
 	if state == nil {
 		state = prep.State
 	}
-	dCode, dT := h.pollDuring(spec)
+	dCode, dT := h.pollDuring(spec, baseT)
 	res.During = obs(dCode, dT)
 
 	var stop actionResponse
@@ -323,11 +324,10 @@ func (h *Harness) RunAttack(spec AttackSpec) AttackResult {
 	} else if stop.Error != nil {
 		res.Detail = "stop: " + stringifyErr(stop.Error)
 	}
-	time.Sleep(3 * time.Second)
-	aCode, aT := h.probe(spec.Endpoint)
+	aCode, aT := h.pollRecovered(spec)
 	res.After = obs(aCode, aT)
 
-	if spec.effectObserved(dCode, dT) && spec.recovered(aCode, aT) {
+	if spec.effectObserved(dCode, dT, baseT) && spec.recovered(aCode, aT) {
 		res.Result = "pass"
 	} else {
 		res.Result = "fail"
@@ -365,19 +365,38 @@ func (h *Harness) Teardown() {
 	if h.net != nil {
 		_ = h.net.Remove(h.ctx)
 	}
+	// Remove the per-cell sample image so a full grid doesn't accumulate ~14 images on disk.
+	if h.sampleTag != "" {
+		_ = exec.CommandContext(h.ctx, "docker", "image", "rm", "-f", h.sampleTag).Run()
+	}
 }
 
 // ---- helpers ----
 
 // pollDuring repeatedly probes the endpoint while an attack is active, returning as
 // soon as the expected effect appears (ByteBuddy instrumentation activates
-// asynchronously after /start, so a single fixed-delay probe is racy). It returns the
-// last observation if the effect never appears within the window.
-func (h *Harness) pollDuring(spec AttackSpec) (int, float64) {
-	deadline := time.Now().Add(10 * time.Second)
+// asynchronously after /start, so a single fixed-delay probe is racy). The window is
+// generous because retransformation on heavier cells (Boot 4.1 / Java 25) can be slow.
+// It returns the last observation if the effect never appears within the window.
+func (h *Harness) pollDuring(spec AttackSpec, baselineSecs float64) (int, float64) {
+	deadline := time.Now().Add(20 * time.Second)
 	for {
 		code, t := h.probe(spec.Endpoint)
-		if spec.effectObserved(code, t) || !time.Now().Before(deadline) {
+		if spec.effectObserved(code, t, baselineSecs) || !time.Now().Before(deadline) {
+			return code, t
+		}
+		time.Sleep(1 * time.Second)
+	}
+}
+
+// pollRecovered polls the endpoint after /stop until the effect clears (de-instrumentation
+// is asynchronous too, so a single post-stop probe is racy). Returns the last observation
+// if it does not recover within the window.
+func (h *Harness) pollRecovered(spec AttackSpec) (int, float64) {
+	deadline := time.Now().Add(15 * time.Second)
+	for {
+		code, t := h.probe(spec.Endpoint)
+		if spec.recovered(code, t) || !time.Now().Before(deadline) {
 			return code, t
 		}
 		time.Sleep(1 * time.Second)

--- a/e2e/spring_boot_sample.go
+++ b/e2e/spring_boot_sample.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"os/exec"
 	"testing"
 	"time"
 
@@ -27,7 +29,32 @@ type SpringBootSample struct {
 	cancelCtx context.CancelFunc
 }
 
+// sampleImage is the in-repo parameterized Spring Boot sample built with its
+// Dockerfile defaults (Spring Boot 3.5.16 / Java 21, RestClient enabled).
+const sampleImage = "jvm-matrix-sample:e2e"
+
+// buildAndLoadSampleImage builds the in-repo sample on the host (buildkit, so the
+// Dockerfile's cache mount works) and loads it into minikube, for both the docker
+// and containerd runtimes. Replaces the previously used external
+// docker.io/steadybit/spring-boot-sample image.
+func (n *SpringBootSample) buildAndLoadSampleImage() error {
+	build := exec.Command("docker", "build", "testdata/samples/springboot", "-t", sampleImage)
+	build.Stdout, build.Stderr = os.Stdout, os.Stderr
+	// The Dockerfile uses `RUN --mount=type=cache`, which requires BuildKit.
+	build.Env = append(os.Environ(), "DOCKER_BUILDKIT=1")
+	if err := build.Run(); err != nil {
+		return fmt.Errorf("failed to build sample image: %w", err)
+	}
+	if err := n.Minikube.LoadImage(sampleImage); err != nil {
+		return fmt.Errorf("failed to load sample image into minikube: %w", err)
+	}
+	return nil
+}
+
 func (n *SpringBootSample) Deploy(podName string, opts ...func(c *acorev1.PodApplyConfiguration)) error {
+	if err := n.buildAndLoadSampleImage(); err != nil {
+		return err
+	}
 	cfg := &acorev1.PodApplyConfiguration{
 		TypeMetaApplyConfiguration: ametav1.TypeMetaApplyConfiguration{
 			Kind:       extutil.Ptr("Pod"),
@@ -41,11 +68,12 @@ func (n *SpringBootSample) Deploy(podName string, opts ...func(c *acorev1.PodApp
 			RestartPolicy: extutil.Ptr(corev1.RestartPolicyNever),
 			Containers: []acorev1.ContainerApplyConfiguration{
 				{
-					Name:  extutil.Ptr("spring-boot-sample"),
-					Image: extutil.Ptr("docker.io/steadybit/spring-boot-sample:1.0.26"),
+					Name:            extutil.Ptr("spring-boot-sample"),
+					Image:           extutil.Ptr(sampleImage),
+					ImagePullPolicy: extutil.Ptr(corev1.PullNever),
 					Ports: []acorev1.ContainerPortApplyConfiguration{
 						{
-							ContainerPort: extutil.Ptr(int32(80)),
+							ContainerPort: extutil.Ptr(int32(8080)),
 						},
 					},
 					Env: []acorev1.EnvVarApplyConfiguration{
@@ -141,7 +169,7 @@ func (n *SpringBootSample) IsReachable() error {
 	}
 	defer client.Close()
 
-	_, err = client.R().Get("/customers")
+	_, err = client.R().Get("/mvc")
 	if err != nil {
 		return err
 	}
@@ -157,7 +185,7 @@ func (n *SpringBootSample) AssertIsReachable(t *testing.T, expected bool) {
 	defer client.Close()
 
 	e2e.Retry(t, 30, 1*time.Second, func(r *e2e.R) {
-		_, err = client.R().Get("/customers")
+		_, err = client.R().Get("/mvc")
 		if expected && err != nil {
 			r.Failed = true
 			statusInfo := n.podStatusInfo()
@@ -193,7 +221,7 @@ func (n *SpringBootSample) GetHttpStatusOfCustomersEndpoint() (int, error) {
 	}
 	defer client.Close()
 
-	response, err := client.R().Get("/customers")
+	response, err := client.R().Get("/mvc")
 	if err != nil {
 		return 0, err
 	}
@@ -202,7 +230,7 @@ func (n *SpringBootSample) GetHttpStatusOfCustomersEndpoint() (int, error) {
 }
 
 func (n *SpringBootSample) MeasureLatency(expectedStatus int) (time.Duration, error) {
-	return n.MeasureLatencyOnPath(expectedStatus, "/customers")
+	return n.MeasureLatencyOnPath(expectedStatus, "/mvc")
 }
 func (n *SpringBootSample) MeasureLatencyOnPath(expectedStatus int, path string) (time.Duration, error) {
 	client, err := n.Minikube.NewRestClientForService(n.Service)
@@ -239,7 +267,7 @@ func (n *SpringBootSample) MeasureUnaffectedLatencyOnPath(expectedStatus int, pa
 }
 
 func (n *SpringBootSample) AssertLatency(t *testing.T, min time.Duration, max time.Duration, unaffectedLatency time.Duration) {
-	n.AssertLatencyOnPath(t, min, max, "/customers", unaffectedLatency)
+	n.AssertLatencyOnPath(t, min, max, "/mvc", unaffectedLatency)
 }
 func (n *SpringBootSample) AssertLatencyOnPath(t *testing.T, min time.Duration, max time.Duration, path string, unaffectedLatency time.Duration) {
 	t.Helper()
@@ -260,7 +288,7 @@ func (n *SpringBootSample) AssertLatencyOnPath(t *testing.T, min time.Duration, 
 }
 
 func (n *SpringBootSample) ExpectedStatus(expectedStatus int) (bool, int, error) {
-	return n.ExpectedStatusOnPath(expectedStatus, "/customers")
+	return n.ExpectedStatusOnPath(expectedStatus, "/mvc")
 }
 func (n *SpringBootSample) ExpectedStatusOnPath(expectedStatus int, path string) (bool, int, error) {
 	client, err := n.Minikube.NewRestClientForService(n.Service)
@@ -279,7 +307,7 @@ func (n *SpringBootSample) ExpectedStatusOnPath(expectedStatus int, path string)
 	return true, response.StatusCode(), nil
 }
 func (n *SpringBootSample) AssertStatus(t *testing.T, expectedHttpStatus int) {
-	n.AssertStatusOnPath(t, expectedHttpStatus, "/customers")
+	n.AssertStatusOnPath(t, expectedHttpStatus, "/mvc")
 }
 func (n *SpringBootSample) AssertStatusOnPath(t *testing.T, expectedHttpStatus int, path string) {
 	t.Helper()

--- a/e2e/testdata/samples/springboot/src/main/java-restclient/com/steadybit/matrix/RestClientController.java
+++ b/e2e/testdata/samples/springboot/src/main/java-restclient/com/steadybit/matrix/RestClientController.java
@@ -6,6 +6,7 @@ package com.steadybit.matrix;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.RestClient;
 
@@ -20,7 +21,8 @@ public class RestClientController {
     }
 
     @GetMapping("/http/restclient")
-    public String restClient() {
-        return "restclient:" + restClient.get().uri(downstreamUrl).retrieve().body(String.class);
+    public String restClient(@RequestParam(name = "url", required = false) String url) {
+        String target = (url == null || url.isEmpty()) ? downstreamUrl : url;
+        return "restclient:" + restClient.get().uri(target).retrieve().body(String.class);
     }
 }

--- a/e2e/testdata/samples/springboot/src/main/java/com/steadybit/matrix/HttpClientController.java
+++ b/e2e/testdata/samples/springboot/src/main/java/com/steadybit/matrix/HttpClientController.java
@@ -5,10 +5,14 @@
 package com.steadybit.matrix;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 
 @RestController
 public class HttpClientController {
@@ -21,13 +25,31 @@ public class HttpClientController {
         this.downstreamUrl = downstreamUrl;
     }
 
+    // Surfaces the downstream status so a test can assert the *exact* injected status code
+    // (the exception would otherwise surface as a generic 500).
     @GetMapping("/http/resttemplate")
-    public String restTemplate() {
-        return "resttemplate:" + restTemplate.getForObject(downstreamUrl, String.class);
+    public ResponseEntity<String> restTemplate(@RequestParam(name = "url", required = false) String url) {
+        try {
+            String body = restTemplate.getForObject(target(url), String.class);
+            return ResponseEntity.ok("resttemplate:" + body);
+        } catch (HttpStatusCodeException e) {
+            return ResponseEntity.status(e.getStatusCode().value()).body("resttemplate-error:" + e.getStatusCode().value());
+        }
     }
 
+    // Surfaces the downstream status so a test can assert the *exact* injected status code
+    // (WebClient would otherwise let the exception surface as a generic 500).
     @GetMapping("/http/webclient")
-    public String webClient() {
-        return "webclient:" + webClient.get().uri(downstreamUrl).retrieve().bodyToMono(String.class).block();
+    public ResponseEntity<String> webClient(@RequestParam(name = "url", required = false) String url) {
+        try {
+            String body = webClient.get().uri(target(url)).retrieve().bodyToMono(String.class).block();
+            return ResponseEntity.ok("webclient:" + body);
+        } catch (WebClientResponseException e) {
+            return ResponseEntity.status(e.getStatusCode().value()).body("webclient-error:" + e.getStatusCode().value());
+        }
+    }
+
+    private String target(String url) {
+        return (url == null || url.isEmpty()) ? downstreamUrl : url;
     }
 }


### PR DESCRIPTION
Runs the minikube e2e (`TestWithMinikube`) against the **in-repo** Spring Boot sample instead of the external `docker.io/steadybit/spring-boot-sample:1.0.26` image — one sample app, no external pinned image.

## Changes
- **Sample**: optional `?url=` on `/http/{resttemplate,webclient,restclient}`; the WebClient **and** RestTemplate endpoints surface the injected downstream status so a test can assert the exact code.
- **e2e harness** (`spring_boot_sample.go`): build the sample on the host (BuildKit) and `minikube image load` it for both runtimes; deploy with `ImagePullPolicy: Never`. Default build = Spring Boot 3.5.16 / Java 21.
- **e2e tests** (`integration_test.go`): retargeted to the sample's surface (`/mvc`, `/jdbc`, `/http/*`, `com.steadybit.matrix.ComputeService`); discovery `spring-instance.name` → `jvm-matrix-sample`, and the discovery test drives a `/jdbc` call so the datasource is captured.
- **http-client status**: `testHttpClientStatus` now runs every case against **both** the reactive (WebClient) and blocking (RestTemplate) clients and asserts the **exact** injected status code (e.g. 502) on each — both take effect on Spring Framework 6+ after #426.
- **Coverage fix**: `testJDBCTemplateException` previously invoked the *java-method* exception attack (a latent copy-paste bug), leaving `spring-jdbctemplate-exception-attack` with **no e2e coverage**. It now exercises that attack against `/jdbc`, so **all 8 attacks are covered**.
- **Assertion fix**: corrected the negative-control latency ceiling (`unaffectedLatency*2`).

## Also carries the matrix-harness review fixes
#424 was squash-merged before the `fix(matrix): …` commit landed, so this PR also brings the matrix-suite scoring/cleanup fixes to `main`: baseline-relative delay scoring, poll-for-recovery, and a wider effect window.

## Notes
- Rebased onto `main` and squashed to a single commit. Depends on #426 (support HTTP-client status injection on Spring Framework 6+), now merged — that fix is what lets the blocking RestTemplate/RestClient status assertion pass on the Boot 3.5 sample.