### PR TITLE
fix(matrix): warm endpoint before baseline probe (fixes false webclient-delay failure)

### DIFF
--- a/e2e/matrix/harness.go
+++ b/e2e/matrix/harness.go
@@ -283,6 +283,10 @@ func (h *Harness) RunAttack(spec AttackSpec) AttackResult {
 		res.Result, res.Detail = "error", "sample target not found"
 		return res
 	}
+	// Warm the endpoint before measuring the baseline: a lazily-initialized client (e.g. WebClient's
+	// first call spins up Netty/DNS/connection pool ~1s) would otherwise make the baseline latency
+	// unrepresentatively high, and the baseline-relative delay scoring would then miss the injected delay.
+	h.probe(spec.Endpoint)
 	baseCode, baseT := h.probe(spec.Endpoint)
 	res.Baseline = obs(baseCode, baseT)
 


### PR DESCRIPTION
## Symptom
A full-grid matrix run with **per-cell** isolation reported `spring-httpclient-delay[webclient]` as ❌ (no effect) in **every** cell, while `[resttemplate]`/`[restclient]` delay and all `status` attacks passed.

## Root cause — measurement artifact, not an attack regression
The delay attack works: the during-attack latency correctly shows ~2 s (the configured `delayMillis=2000`). The harness mis-scored it:

- `effectObserved` for delay is baseline-relative: `during − baseline ≥ 1.5s` (75% of 2 s).
- The **baseline probe hit a cold `WebClient`** — the first `WebClient.create()` request lazily spins up Netty/DNS/the connection pool (~1 s). So baseline ≈ 1.0 s instead of the ~4 ms steady state (`after` shows 0.004 s).
- `during − baseline = 2.006 − 1.0 ≈ 1.0 s < 1.5 s` → false "no effect".

This only surfaced now because per-cell isolation makes the delay attack the *first* WebClient call, and #425's baseline-relative scoring (previously absolute) subtracts that inflated baseline. Observed:
- before (absolute scoring): `base=1.212 during=2.025` → pass
- now (baseline-relative): `base=1.001 during=2.006` → fail

`status[webclient]` is unaffected because it scores on `code ≥ 500`, not latency.

## Fix
Take one throwaway warm-up probe before measuring the baseline, so the baseline reflects steady-state latency. Keeps the (correct) baseline-relative scoring.