### PR TITLE
ci: migrate to npm 12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,6 +317,7 @@ jobs:
 
       # this commit will effectively cause another run of the workflow which then actually performs the helm chart release
       - run: |
+          npm install -g npm@12
           npm install --ignore-scripts -g semver@7.7.4
           make chart-bump-version APP_VERSION="${{ needs.build-images.outputs.version }}"
           git config user.name "$GITHUB_ACTOR"


### PR DESCRIPTION
npm 12 disables dependency install scripts (plus git and remote-URL dependencies) by default — see the [npm v12.0.0 release notes](https://github.com/npm/cli/releases/tag/v12.0.0).

This workflow only uses npm to install global CLI tools; upgrade to npm 12 first so those installs run under the new script-blocking defaults.

Part of the org-wide npm 12 CI migration.
