### PR TITLE
ci: pin npm to exact version 12.0.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,7 +317,7 @@ jobs:
 
       # this commit will effectively cause another run of the workflow which then actually performs the helm chart release
       - run: |
-          npm install -g npm@12
+          npm install -g npm@12.0.2
           npm install --ignore-scripts -g semver@7.7.4
           make chart-bump-version APP_VERSION="${{ needs.build-images.outputs.version }}"
           git config user.name "$GITHUB_ACTOR"


### PR DESCRIPTION
SonarCloud's GitHub Actions dependency-hardening rules flag `npm install -g npm@12` as an unpinned dependency installation (floating range = supply-chain risk); the same finding just failed the platform nightly quality gate. This pins the npm upgrade to the exact version `12.0.2`. Future npm 12.x patches now need an explicit bump.