### PR TITLE
ci: add --ignore-scripts to npm tool installs (Sonar)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,7 +317,7 @@ jobs:
 
       # this commit will effectively cause another run of the workflow which then actually performs the helm chart release
       - run: |
-          npm install -g npm@12.0.2
+          npm install -g --ignore-scripts npm@12.0.2
           npm install --ignore-scripts -g semver@7.7.4
           make chart-bump-version APP_VERSION="${{ needs.build-images.outputs.version }}"
           git config user.name "$GITHUB_ACTOR"


### PR DESCRIPTION
SonarCloud flags npm installs in workflows that omit `--ignore-scripts` as major vulnerabilities ("Omitting --ignore-scripts allows lifecycle scripts to run during package installation") — this is what actually failed the platform nightly quality gate, not version pinning. Adds `--ignore-scripts` to the npm self-install (the npm package has no lifecycle scripts; verified 12.0.2 installs and runs correctly with the flag).