### PR TITLE
chore(linuxpkg): drop the unused procps dependency

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -61,8 +61,8 @@ nfpms:
     builds:
       - steadybit-extension-jvm
     dependencies:
-      - procps
       - runc
+      # capsh, used by the sysv init.d script
       - libcap2-bin
     bindir: /opt/steadybit/extension-jvm
     contents:
@@ -96,7 +96,6 @@ nfpms:
     overrides:
       rpm:
         dependencies:
-          - /usr/bin/ps
           - runc
           - /usr/sbin/capsh
 


### PR DESCRIPTION
## What

Drops `procps` (deb) / `/usr/bin/ps` (rpm) from the `nfpms` dependencies.

The jvm extension never execs `ps`, `pkill` or `/bin/kill`:

- process discovery uses `gopsutil` (pure `/proc` reads),
- the only `"kill"` in the code is `runc kill` via `action_kit_commons/ociruntime`,
- the signalling helpers from `action_kit_commons` (`stress`, `memfill`, `diskfill`, `dnsinject`) — the reason extension-host and extension-container need `/bin/kill` — are not used here; the only `action_kit_commons` package imported is `ociruntime`.

`runc` and `libcap2-bin` / `/usr/sbin/capsh` stay (the latter is used by the SysV `init.d` script), now with a comment saying why.

Related: steadybit/extension-host#247, steadybit/extension-container#494.

## Not in this PR

The `Dockerfile` also installs `procps` and is equally unused by the code — left alone deliberately, since `ps` inside the container is handy when debugging a pod. Happy to drop it too if you'd rather.

## Verification

`goreleaser check` passes (only the pre-existing `nfpms.builds` deprecation warning).